### PR TITLE
updates to swoop-db helm chart for revoke connect

### DIFF
--- a/charts/swoop-db-init/templates/postgres-role-secrets.yaml
+++ b/charts/swoop-db-init/templates/postgres-role-secrets.yaml
@@ -42,3 +42,12 @@ type: Opaque
 data:
   username: {{ .Values.postgres.service.ownerRoleUsername }}
   password: {{ .Values.postgres.service.ownerRolePassword }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pg-rw-role-secret
+type: Opaque
+data:
+  username: {{ .Values.postgres.service.rwRoleUsername }}
+  password: {{ .Values.postgres.service.rwRolePassword }}

--- a/charts/swoop-db-init/templates/swoop-db-init-job.yaml
+++ b/charts/swoop-db-init/templates/swoop-db-init-job.yaml
@@ -65,6 +65,16 @@ spec:
             secretKeyRef:
               name: pg-owner-role-secret
               key: password
+        - name: RW_ROLE_USER
+          valueFrom:
+            secretKeyRef:
+              name: pg-rw-role-secret
+              key: username
+        - name: RW_ROLE_PASS
+          valueFrom:
+            secretKeyRef:
+              name: pg-rw-role-secret
+              key: password
         resources:
           requests:
             cpu: 1

--- a/charts/swoop-db-init/values.yaml
+++ b/charts/swoop-db-init/values.yaml
@@ -58,3 +58,11 @@ postgres:
     conductorRolePasswordSecret:
       name: pg-conductor-role-secret
       key: password
+    rwRoleUsername: c3dvb3BfcmVhZHdyaXRl
+    rwRolePassword: cGFzc19yZWFkd3JpdGU=
+    rwRoleUsernameSecret:
+      name: pg-rw-role-secret
+      key: username
+    rwRolePasswordSecret:
+      name: pg-rw-role-secret
+      key: password


### PR DESCRIPTION
Updates to swoop-db helm chart for adding capability to revoke and grant connection privileges before and after running migrations, respectively